### PR TITLE
feat: mobile improvements

### DIFF
--- a/components/LocaleSearch.vue
+++ b/components/LocaleSearch.vue
@@ -47,6 +47,8 @@ const { data: files, execute, status, error} = await useLazyAsyncData<BlogSearch
     }
 )
 
+const { t } = useI18n()
+
 // Filter search index to only the current locale, derived from the route path
 const route = useRoute()
 const localFiles = computed(() => {
@@ -193,24 +195,26 @@ watch(Escape, () => {
     <button
         class="border-gray-200 border p-1 px-2 rounded-lg text-sm hover:border-gray-400 flex items-center justify-center gap-1 dark:text-slate-100 hover:dark:text-slate-400"
         type="button"
-        aria-label="Search"
+        :aria-label="t('ui.search')"
         @click="showSearch"
     >
         <svg class="w-3 h-3 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z" />
         </svg>
-        <span>Search</span>
+        <span>{{ t('ui.search') }}</span>
     </button>
 
     <!-- eslint-disable-next-line vue/no-multiple-template-root -->
     <teleport to="body">
+        <Transition name="search-backdrop">
         <div
             v-if="show"
             ref="searchContentRef"
             class="bg-slate-600 bg-opacity-75 fixed top-0 right-0 bottom-0 left-0 z-50 flex justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
             @click="show = false"
         >
-            <div class="relative p-4 w-full max-w-2xl overflow-auto max-h-2xl">
+            <Transition name="search-modal" appear>
+            <div v-if="show" class="relative p-4 w-full max-w-2xl overflow-auto max-h-2xl">
                 <div
                     class="relative bg-white rounded-lg shadow dark:bg-gray-700 dark:border-gray-600 dark:border"
                     @click.stop
@@ -285,7 +289,9 @@ watch(Escape, () => {
                     </div>
                 </div>
             </div>
+            </Transition>
         </div>
+        </Transition>
     </teleport>
 </template>
 
@@ -311,5 +317,24 @@ watch(Escape, () => {
 
 .search-result-content-preview {
     @apply truncate relative text-slate-400 text-sm;
+}
+
+.search-backdrop-enter-active,
+.search-backdrop-leave-active {
+    transition: opacity 0.2s ease;
+}
+.search-backdrop-enter-from,
+.search-backdrop-leave-to {
+    opacity: 0;
+}
+
+.search-modal-enter-active,
+.search-modal-leave-active {
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.search-modal-enter-from,
+.search-modal-leave-to {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.98);
 }
 </style>

--- a/components/MinimalistMenu.vue
+++ b/components/MinimalistMenu.vue
@@ -1,6 +1,8 @@
 <template>
   <nav class="mt-5 w-3/4 mx-auto">
-    <div class="flex items-center">
+
+    <!-- Desktop -->
+    <div class="hidden md:flex items-center">
       <div class="flex gap-5 flex-1 text-sm tracking-wide text-gray-500 dark:text-gray-400">
         <NuxtLink
           :to="localePath('/')"
@@ -18,48 +20,109 @@
         </NuxtLink>
       </div>
       <div class="flex items-center gap-3">
-        <!-- Language switcher -->
         <div class="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
           <NuxtLink
             :to="switchLocalePath('pt')"
             :class="locale === 'pt' ? 'text-gray-900 dark:text-white font-medium' : 'hover:text-sky-500 dark:hover:text-sky-400 transition-colors'"
-          >
-            PT
-          </NuxtLink>
+          >PT</NuxtLink>
           <span aria-hidden="true">·</span>
           <NuxtLink
             :to="switchLocalePath('en')"
             :class="locale === 'en' ? 'text-gray-900 dark:text-white font-medium' : 'hover:text-sky-500 dark:hover:text-sky-400 transition-colors'"
-          >
-            EN
-          </NuxtLink>
+          >EN</NuxtLink>
         </div>
-        <div>
         <button
-          v-if="!isDark"
           class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
-          aria-label="Switch to dark mode"
+          :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
           @click="toggleDark()"
         >
-          <svg fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+          <svg v-if="!isDark" fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
             <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z" />
           </svg>
-        </button>
-        <button
-          v-if="isDark"
-          class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
-          aria-label="Switch to light mode"
-          @click="toggleDark()"
-        >
-          <svg fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <svg v-else fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
             <path d="M144.7 98.7c-21 34.1-33.1 74.3-33.1 117.3c0 98 62.8 181.4 150.4 211.7c-12.4 2.8-25.3 4.3-38.6 4.3C126.6 432 48 353.3 48 256c0-68.9 39.4-128.4 96.8-157.3zm62.1-66C91.1 41.2 0 137.9 0 256C0 379.7 100 480 223.5 480c47.8 0 92-15 128.4-40.6c1.9-1.3 3.7-2.7 5.5-4c4.8-3.6 9.4-7.4 13.9-11.4c2.7-2.4 5.3-4.8 7.9-7.3c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-3.7 .6-7.4 1.2-11.1 1.6c-5 .5-10.1 .9-15.3 1c-1.2 0-2.5 0-3.7 0c-.1 0-.2 0-.3 0c-96.8-.2-175.2-78.9-175.2-176c0-54.8 24.9-103.7 64.1-136c1-.9 2.1-1.7 3.2-2.6c4-3.2 8.2-6.2 12.5-9c3.1-2 6.3-4 9.6-5.8c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-3.6-.3-7.1-.5-10.7-.6c-2.7-.1-5.5-.1-8.2-.1c-3.3 0-6.5 .1-9.8 .2c-2.3 .1-4.6 .2-6.9 .4z" />
           </svg>
         </button>
-        </div>
       </div>
     </div>
+
+    <!-- Mobile: hamburger toggle -->
+    <div class="md:hidden flex items-center justify-between">
+      <span class="text-xs text-gray-400 dark:text-gray-500">
+        <NuxtLink
+          :to="switchLocalePath('pt')"
+          :class="locale === 'pt' ? 'text-gray-900 dark:text-white font-medium' : 'hover:text-sky-500 dark:hover:text-sky-400 transition-colors'"
+        >PT</NuxtLink>
+        <span aria-hidden="true"> · </span>
+        <NuxtLink
+          :to="switchLocalePath('en')"
+          :class="locale === 'en' ? 'text-gray-900 dark:text-white font-medium' : 'hover:text-sky-500 dark:hover:text-sky-400 transition-colors'"
+        >EN</NuxtLink>
+      </span>
+      <button
+        class="p-2 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
+        :aria-label="menuOpen ? 'Close menu' : 'Open menu'"
+        @click="menuOpen = !menuOpen"
+      >
+        <!-- Hamburger -->
+        <svg v-if="!menuOpen" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+        <!-- Close -->
+        <svg v-else class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Mobile: dropdown menu -->
+    <Transition name="menu">
+    <div v-if="menuOpen" class="md:hidden mt-3 flex flex-col gap-4 border-t border-gray-100 dark:border-neutral-800 pt-4 pb-2">
+      <NuxtLink
+        :to="localePath('/')"
+        class="text-sm text-gray-500 dark:text-gray-400 hover:text-sky-500 dark:hover:text-sky-400 transition-colors"
+        @click="menuOpen = false"
+      >
+        {{ t('nav.home') }}
+      </NuxtLink>
+      <NuxtLink
+        v-for="item in menu"
+        :key="item.path"
+        :to="localePath(item.path)"
+        class="text-sm text-gray-500 dark:text-gray-400 hover:text-sky-500 dark:hover:text-sky-400 transition-colors"
+        @click="menuOpen = false"
+      >
+        {{ t(`nav.${item.name.toLowerCase()}`, item.name) }}
+      </NuxtLink>
+      <button
+        class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-sky-500 dark:hover:text-sky-400 transition-colors w-fit"
+        @click="toggleDark()"
+      >
+        <svg v-if="!isDark" fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+          <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z" />
+        </svg>
+        <svg v-else fill="currentColor" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+          <path d="M144.7 98.7c-21 34.1-33.1 74.3-33.1 117.3c0 98 62.8 181.4 150.4 211.7c-12.4 2.8-25.3 4.3-38.6 4.3C126.6 432 48 353.3 48 256c0-68.9 39.4-128.4 96.8-157.3zm62.1-66C91.1 41.2 0 137.9 0 256C0 379.7 100 480 223.5 480c47.8 0 92-15 128.4-40.6c1.9-1.3 3.7-2.7 5.5-4c4.8-3.6 9.4-7.4 13.9-11.4c2.7-2.4 5.3-4.8 7.9-7.3c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-3.7 .6-7.4 1.2-11.1 1.6c-5 .5-10.1 .9-15.3 1c-1.2 0-2.5 0-3.7 0c-.1 0-.2 0-.3 0c-96.8-.2-175.2-78.9-175.2-176c0-54.8 24.9-103.7 64.1-136c1-.9 2.1-1.7 3.2-2.6c4-3.2 8.2-6.2 12.5-9c3.1-2 6.3-4 9.6-5.8c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-3.6-.3-7.1-.5-10.7-.6c-2.7-.1-5.5-.1-8.2-.1c-3.3 0-6.5 .1-9.8 .2c-2.3 .1-4.6 .2-6.9 .4z" />
+        </svg>
+        {{ isDark ? t('ui.lightMode') : t('ui.darkMode') }}
+      </button>
+    </div>
+    </Transition>
+
   </nav>
 </template>
+
+<style scoped>
+.menu-enter-active,
+.menu-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.menu-enter-from,
+.menu-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+</style>
 
 <script setup lang="ts">
 import { useDark, useToggle } from '@vueuse/core'
@@ -70,7 +133,13 @@ const menu = config.menu || []
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
 
+const menuOpen = ref(false)
+
 const { locale, t } = useI18n()
 const localePath = useLocalePath()
 const switchLocalePath = useSwitchLocalePath()
+
+// Close menu on route change
+const route = useRoute()
+watch(() => route.path, () => { menuOpen.value = false })
 </script>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -11,5 +11,10 @@
   },
   "archives": {
     "title": "All Posts"
+  },
+  "ui": {
+    "search": "Search",
+    "lightMode": "Light mode",
+    "darkMode": "Dark mode"
   }
 }

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -11,5 +11,10 @@
   },
   "archives": {
     "title": "Todos os Posts"
+  },
+  "ui": {
+    "search": "Buscar",
+    "lightMode": "Modo claro",
+    "darkMode": "Modo escuro"
   }
 }

--- a/layouts/themes/minimalist/default.vue
+++ b/layouts/themes/minimalist/default.vue
@@ -3,7 +3,7 @@
     <MinimalistHeader />
     <MinimalistMenu />
 
-    <main class="mt-10 w-full max-w-2xl mx-6 lg:mx-auto px-4 lg:px-0">
+    <main class="mt-10 max-w-2xl mx-auto w-full px-6">
       <div v-if="doc">
         <div class="text-center">
           <h2 class="text-3xl font-bold">{{ (doc as any).title }}</h2>
@@ -72,6 +72,11 @@ function formatDate(date: string): string {
   h5 a,
   h6 a {
     @apply no-underline;
+  }
+
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- **Fix horizontal scroll on article pages** — replaced `w-full mx-6` (which overflows the viewport) with `max-w-2xl mx-auto px-6`; added `pre { overflow-x: auto }` so code blocks scroll internally
- **Responsive hamburger menu** — below `md` breakpoint the nav collapses into a `☰` button with a smooth slide-down animation; desktop layout is unchanged
- **Search modal animations** — backdrop fades in, modal card slides down + scales up on open (reverses on close)
- **i18n UI strings** — "Search", "Light mode", "Dark mode" are now translated via `t()` in both PT and EN locale files

## Test plan

- [ ] Open an article with code blocks on mobile — no horizontal scroll
- [ ] Resize to mobile width — nav collapses to `PT · EN` + hamburger
- [ ] Tap hamburger — menu slides down smoothly; links close menu on tap
- [ ] Open search — backdrop fades in, modal drops into place
- [ ] Switch to EN — Search button shows "Search", dark toggle shows "Dark mode"
- [ ] Switch to PT — Search button shows "Buscar", dark toggle shows "Modo escuro"
- [ ] Desktop — layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)